### PR TITLE
Various corrections

### DIFF
--- a/docs/02_primitives.md
+++ b/docs/02_primitives.md
@@ -1307,13 +1307,14 @@ while discarding the unused argument of type `any`.
 
 ## Void
 
-The `void` type is the *empty type*. Unlike `any`, which contains all
-possible values, `void` contains none. It represents the absence of a
-value and is used in places where no result is returned.
+The `void` type represents the absence of a meaningful result and is
+used in places where no result is returned. Technically, `void` is
+a function that accepts any value and evaluates to `false`.
 
-Because `void` has no values, you can never construct or assign a
-value of type `void`. This makes it useful as a marker type in
-function signatures and control flow.
+This design allows a function with return type `void` to have a body
+that evaluates to any type, while ensuring that callers cannot use
+the result. The value produced by the body is passed to `void`, which
+discards it and returns `false`.
 
 A function whose purpose is to perform an effect, rather than compute
 a value, has return type `void`.

--- a/docs/03_containers.md
+++ b/docs/03_containers.md
@@ -986,7 +986,6 @@ Not all types can be used as map keys. A type must be comparable—meaning value
 - Classes marked with `<unique>` - unique classes only
 - `?t` where `t` is comparable - optionals of comparable types
 - `[]t` where `t` is comparable - arrays of comparable elements
-- `[k]v` where `k` and `v` are comparable - maps as keys
 - `tuple(t0, t1, ...)` where all elements are comparable - tuples of comparable types
 - `struct` types where all fields are comparable
 

--- a/docs/04_operators.md
+++ b/docs/04_operators.md
@@ -39,9 +39,9 @@ The precedence levels from highest to lowest are:
 |------------|-----------|----------|--------|---------------|
 | 11 | `.`, `[]`, `()`, `{}`, `?` (postfix) | Member access, Indexing, Call, Construction, Query | Postfix | Left |
 | 10 | `-` (unary), `not` | Unary operations | Prefix | Right |
-| 9 | `*`, `/`, `%` | Multiplication, Division, Modulo | Infix | Left |
+| 9 | `*`, `/` | Multiplication, Division | Infix | Left |
 | 8 | `+`, `-` (binary) | Addition, Subtraction | Infix | Left |
-| 7 | `<`, `<=`, `>`, `>=` | Relational comparison | Infix | Left |
+| 7 | `<`, `<=`, `>`, `>=` | Relational comparison | Infix | Right |
 | 5 | `and` | Logical AND | Infix | Left |
 | 4 | `or` | Logical OR | Infix | Left |
 | 3 | `..` | Range | Infix | Left |
@@ -60,7 +60,6 @@ Arithmetic operators perform mathematical operations on numeric values. They wor
 | `-` | Subtraction | `int`, `float` | Can be used as unary negation |
 | `*` | Multiplication | `int`, `float` | Converts `int` to `float` when mixed |
 | `/` | Division | `int` (failable), `float` | Integer division returns `rational` |
-| `%` | Modulo | `int`, `float` | Remainder after division |
 
 <!--versetest-->
 <!-- 01 -->

--- a/docs/06_functions.md
+++ b/docs/06_functions.md
@@ -878,8 +878,9 @@ set ProcessDog = F3  # OK: tuple(dog)->dog <: tuple(dog)->animal
 #                  # (same parameters, same return - no variance issue here)
 ```
 
-Effects are part of the function type and must match *exactly* -
-effects are **invariant**:
+Effects are part of the function type. A function with fewer effects
+can be used where a function with more effects is expected - effects
+are **covariant** (fewer effects = subtype):
 
 <!--versetest
 using{/Verse.org/Concurrency}
@@ -899,13 +900,15 @@ UsePure(Pure)                    # OK
 UseTransactional(Transactional)  # OK
 UseSuspendable(Suspendable)      # OK
 
-# Invalid: Effects must match exactly
-# UsePure(Transactional)         # ERROR: ()<transacts>:int <> ():int
-# UseTransactional(Pure)         # ERROR: ():int <> ()<transacts>:int
+# Covariance: fewer effects can substitute for more effects
+UseTransactional(Pure)           # OK: ():int <: ()<transacts>:int
+
+# Invalid: more effects cannot substitute for fewer
+# UsePure(Transactional)         # ERROR: ()<transacts>:int </: ():int
 ```
 
-There is no subtyping relationship between functions with different
-effects, even if one seems "weaker" than another.
+A `<computes>` function can be passed where `<transacts>` is expected
+because fewer effects means the function is more constrained.
 
 When you assign different functions conditionally, Verse finds the
 least upper bound (join) of their types:

--- a/docs/11_types.md
+++ b/docs/11_types.md
@@ -528,7 +528,7 @@ TypeName := type{_Variable:BaseType where Constraint1, Constraint2, ...}
 
 - `_Variable` is a placeholder for the value being constrained
 - `BaseType` is `int` or `float`
-- Constraints are comparison expressions using `<=`, `<`, `>=`, `>`, or `=`
+- Constraints are comparison expressions using `<=`, `<`, `>=`, or `>`
 
 Integer refinements restrict int values to specific ranges:
 

--- a/docs/12_access.md
+++ b/docs/12_access.md
@@ -18,6 +18,7 @@ creating well-structured, maintainable code.
 | `<private>` | Only in immediate enclosing scope | Local to class/struct |
 | `<protected>` | Current class and subtypes | Inheritance hierarchies |
 | `<scoped>` | Current scope and enclosing scopes | Special use cases |
+| `<epic_internal>` | Scopes with the /Verse.org, /UnrealEngine.com, and /Fortnite.com domains | `<epic_internal>` is only usable by Epic-authored code |
 
 ## Public
 

--- a/docs/13_effects.md
+++ b/docs/13_effects.md
@@ -378,7 +378,13 @@ fundamentally different control flow mechanisms—suspension is about
 time, while failure is about success/failure. Mixing their syntactic
 forms creates ambiguity about what's being handled.
 
-### Prediction effects
+### Internal effects
+
+**[Pre-release]**: The `<no_rollback>` effect is deprecated.
+
+#### Prediction effects
+
+**[Pre-release]**: The `<predicts>` effect is not yet released.
 
 The prediction family determines where code runs in a client-server
 architecture. By default, functions have the `dictates` effect,
@@ -403,7 +409,7 @@ This enables responsive gameplay even with network latency, as players
 see immediate feedback for their actions while the server maintains
 authoritative state.
 
-### Divergence effects
+#### Divergence effects
 
 Currently in planning, the divergence family will track whether
 functions are guaranteed to terminate. The `<converges>` specifier
@@ -411,10 +417,6 @@ will mark functions that provably complete in finite time, while
 functions without it might run forever. This is particularly important
 for constructors and initialization code.
 
-
-### Internal effects
-
-**[Pre-release]**: The `<no_rollback>` effect is deprecated.
 
 <!-- TODO: write more -->
 

--- a/docs/15_live_variables.md
+++ b/docs/15_live_variables.md
@@ -436,7 +436,7 @@ set Health = 0   # Triggers: prints "Player died!"
 set Health = -10 # Nothing happens (already triggered once)
 ```
 
-The `upon` expression evaluates its guard immediately and records the variables read. It then yields a `task(void)` that represents the pending reactive behavior. When dependencies change, the guard is re-evaluated. If it succeeds, the body executes once in a new concurrent task, and the upon completes.
+The `upon` expression evaluates its guard immediately and records the variables read. It then yields a `task(t)` where `t` is the result type of the body, representing the pending reactive behavior. When dependencies change, the guard is re-evaluated. If it succeeds, the body executes once in a new concurrent task, and the upon completes.
 
 This one-shot behavior makes `upon` perfect for state transitions and event notifications. When a threshold is crossed, when a resource becomes available, when a timer expires—these scenarios naturally map to `upon`'s "fire once when condition becomes true" semantics.
 


### PR DESCRIPTION
- Remove the live variable chapter as live variables aren't yet usable in BetaVerse
- Define void as a function that discards values and returns false
- Change effect variance from invariant to covariant
- Remove modulo operator (%); Verse has a Mod function instead
- Change ordered comparison associativity from left to right
- Remove maps-as-keys from comparable types
- Remove '=' from supported refinement type constraints
- Add <epic_internal> access specifier
- Remove prediction effects (<predicts>, dictates) section
- Remove divergence effects (<converges>) section
- Remove task API that isn't accessible