### PR TITLE
Verse Lexer fixes and styling

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,12 +17,20 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+
     - scheme: default
       primary: black
       accent: deep orange
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
+        
+    - scheme: VerseDark
+      primary: black
+      accent: deep orange
+      toggle:
+        icon: material/Format-Color-Text
+        name: Switch to VerseDark
   features:
 #    - content.footnote.tooltips
 #    - navigation.tabs
@@ -52,6 +60,7 @@ plugins:
 
 extra_css:
   - extra.css
+  - VerseDark.css
 
 nav:
   - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,22 +15,15 @@ theme:
       primary: black
       accent: deep orange
       toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
+        icon: material/brightness-7
+        name: Switch to Light mode
 
     - scheme: default
       primary: black
       accent: deep orange
       toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-        
-    - scheme: VerseDark
-      primary: black
-      accent: deep orange
-      toggle:
-        icon: material/Format-Color-Text
-        name: Switch to VerseDark
+        icon: material/brightness-2
+        name: Switch to Dark mode
   features:
 #    - content.footnote.tooltips
 #    - navigation.tabs

--- a/verse_lexer/verse.py
+++ b/verse_lexer/verse.py
@@ -119,7 +119,7 @@ class VerseLexer(RegexLexer):
             (r'[0-9][0-9_]*', Number.Integer),
 
             # String literals
-            (r'"(\\\\|\\[^\\]|[^"\\])*"', String.Double),
+            (r'"', String.Double, 'string-double'),
             (r"'(\\\\|\\[^\\]|[^'\\])*'", String.Single),
 
             # Operators
@@ -159,6 +159,18 @@ class VerseLexer(RegexLexer):
             (r'\.', Punctuation),                   # Dot in package names
             (r',', Punctuation),
             (r'\}', Punctuation, '#pop'),
+        ],
+
+        'string-double': [
+            (r'<#', Comment.Multiline, 'multiline-comment'), # Comments are allowed inside strings
+            (r'\{', String.Interpol, 'interpolation'),
+            (r'[^"\\{<]+', String.Double),
+            (r'"', String.Double, '#pop'),
+        ],
+
+        'interpolation': [
+            (r'\}', String.Interpol, '#pop'),
+            include('root'), 
         ],
     }
 

--- a/verse_lexer/verse.py
+++ b/verse_lexer/verse.py
@@ -81,6 +81,7 @@ class VerseLexer(RegexLexer):
             (r'\s+', Whitespace),
 
             # Comments
+            (r'^\s*<#>\s*\n', Comment.Multiline, 'indented-comment'),
             (r'#[^\n]*', Comment.Single),
             (r'<#', Comment.Multiline, 'multiline-comment'),
 
@@ -150,6 +151,13 @@ class VerseLexer(RegexLexer):
             (r'#>', Comment.Multiline, '#pop'),    # End comment
             (r'[^<#]+', Comment.Multiline),        # Comment content
             (r'[<#]', Comment.Multiline),          # Single < or #
+        ],
+
+        'indented-comment': [
+            (r'^(?=[ ]{0,3}\S)', Text, '#pop'),
+            (r'^[ ]{4,}', Comment.Multiline),   # Indentation (4+ spaces)
+            (r'[^\n]+', Comment.Multiline),
+            (r'\n', Comment.Multiline),
         ],
 
         'using-block': [


### PR DESCRIPTION
- Added support for string interp 
- Comments are now parsed in string-double fixing [string-literals](https://verselang.github.io/book/01_expressions/#string-literals) example
- Added support for Indented Comments fixing [comments](https://verselang.github.io/book/00_overview/#comments) example
- Switch theme button icons to reflect the next state
  - Dark mode now showing a moon icon