### PR TITLE
Fixed typo: "ratioanl" to "rational"

### DIFF
--- a/docs/11_types.md
+++ b/docs/11_types.md
@@ -24,7 +24,7 @@ most general.
 
 Consider the relationship between `rational` and `int`. Every
 integer is a rational number, but not every rational is an integer.
-Therefore, `int` is a subtype of `ratioanl`. This means you can
+Therefore, `int` is a subtype of `rational`. This means you can
 pass an `int` to any function expecting a `rational`, but not vice versa:
 
 <!--versetest


### PR DESCRIPTION
Simple typo fixed in the type system section.