### PR TITLE
Fix for Last Edited and Last Created footer info

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            docs
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -645,7 +645,7 @@ The dotted style uses a period to introduce the expression:
 <!--NoCompile-->
 <!-- 24 -->
 ```verse
-Result := if (Score > 90). "excellent" else. "needs improvement"
+Result := if (Score > 90). "excellent" else if (Score > 70). "good" else. "needs improvement" 
 ```
 
 You can even mix styles when it makes sense:

--- a/docs/01_expressions.md
+++ b/docs/01_expressions.md
@@ -208,10 +208,15 @@ F():void=
 -->
 <!-- 11 -->
 ```verse
-LongMessage := "This is a multi-line{
-}string that continues across{
+LongMessage := "This is a multi-line {
+}string that continues across {
 }multiple lines."
-# Result: "This is a multi-linestring that continues acrossmultiple lines."
+# Result: "This is a multi-line string that continues across multiple lines."
+
+OtherMessage := "Another message{
+}    with some empty{
+}    spaces."
+# Result := "Another message    with some empty    spaces."
 ```
 
 Empty interpolants are ignored:
@@ -343,7 +348,7 @@ distinguish between these different kinds of identifiers:
 <!-- 22 -->
 ```verse
 int               # Reference to the int type
-GetValue()        # Reference to a function
+GetValue          # Reference to a function
 Counter           # Reference to a variable
 my_class          # Reference to a class
 ```
@@ -864,9 +869,9 @@ set Map[Key] = MappedValue    # Map entry assignment
 
 Set expressions are themselves expressions, though they're typically
 used for their side effects rather than their value. The left-hand
-side must be a valid lvalue—something that can be assigned to.
+side must be a valid LValue—something that can be assigned to.
 
-Complex lvalues are supported, allowing updates deep within data structures:
+Complex LValues are supported, allowing updates deep within data structures:
 
 <!--verse
 item := class{Name:string = "Item"}

--- a/docs/02_primitives.md
+++ b/docs/02_primitives.md
@@ -643,22 +643,25 @@ Lerp(-10.0, 10.0, 0.5)  # Returns 0.0
 
 The formula is: `From + Parameter * (To - From)`
 
-`IsFinite` checks if a float is finite and returns `true` if the value
-is not NaN, Inf, or -Inf:
+`IsFinite` checks if a float is finite and suceeds if the value
+is not NaN, Inf, or -Inf. And fails otherwise:
 
 <!--versetest-->
 <!-- 33 -->
 ```verse
 # Method on float values
-# X.IsFinite():logic
+# X.IsFinite()<computes><decides>:float
 
-(5.0).IsFinite[]      # Returns true
-(0.0).IsFinite[]      # Returns true
-(-100.0).IsFinite[]   # Returns true
+(5.0).IsFinite[]      # succeeds
+(0.0).IsFinite[]      # succeeds
+(-100.0).IsFinite[]   # succeeds
 
-not (Inf).IsFinite[]  # Returns false
-not (-Inf).IsFinite[] # Returns false
-not (NaN).IsFinite[]  # Returns false
+(Inf).IsFinite[]  # fails
+(-Inf).IsFinite[] # fails
+(NaN).IsFinite[]  # fails
+
+# Returns the same number if succeeds
+(15.16).IsFinite[] = 15.16 # succeeds, both are equal
 
 # Useful for validation
 # SafeCalculation(X:float, Y:float)<decides>:float =
@@ -775,7 +778,7 @@ MyName:string="J"
 ```verse
 TheLetterJ := MyName[0]     # succeeds
 TheLetterJ = 'J'            # succeeds
-# MyName[100]              # fails
+# MyName[100]               # fails
 ```
 
 The length of a string is the number of UTF-8 code units it contains,
@@ -947,9 +950,15 @@ Strings can span multiple lines using interpolation braces for continuation:
 <!--versetest-->
 <!-- 50 -->
 ```verse
-LongMessage := "This is a multi-line{
-}string that continues across{
+LongMessage := "This is a multi-line {
+}string that continues across {
 }multiple lines."
+
+# Attention to whitespace:
+AnotherMessage := "This is another {
+}  multi-line message with     {
+    # This comment is ignored
+}    many spaces."
 ```
 
 Empty interpolants `{}` are ignored, which is useful for line
@@ -1176,7 +1185,7 @@ potentially failing:
 ```verse
 # Function that might produce a value of any type
 MaybeValue(T:type, Condition:logic):?T =
-    if (Condition):
+    if (Condition?):
         # Cannot construct T generically, return failure
         false
     else:

--- a/docs/03_containers.md
+++ b/docs/03_containers.md
@@ -1,6 +1,6 @@
 # Container Types
 
-Container types in Verse manage collections and structured data. Optionals represent values that may or may not be present. Tuples group multiple values of different types into ordered sequences. Arrays hold zero or more values regardless of the type with efficient indexed access. Maps associate keys with values for fast lookups. Weak maps extend regular maps with weak reference semantics for persistent storage.
+Container types in Verse manage collections and structured data. Optionals represent values that may or may not be present. Tuples group multiple values of different types into ordered sequences. Arrays hold zero or more values with efficient indexed access. Maps associate keys with values for fast lookups. Weak maps extend regular maps with weak reference semantics for persistent storage.
 
 Let's explore each container type in detail, starting with optionals that elegantly handle the presence or absence of values.
 
@@ -94,8 +94,7 @@ A common use case is searching for something that may or may not be there. Imagi
 ```verse
 Find(N:[]int, X:int):?int =
     for (I := 0..N.Length):
-        if (N[I] = X):
-            return option{I}
+        if (N[I] = X) then return option{I}
     return false
 
 var Numbers:[]int = array{10, 20, 30}
@@ -1496,7 +1495,7 @@ This applies to complete map replacements (for local variables), individual entr
 !!! warning "Important"
     Current island limits and rules may vary and not match exactly the values shown bellow
 
-There is a **limit on the number of persistent `weak_map` variables** per island. In the standard environment, this limit is 4 persistent weak_maps. Exceeding this limit produces error 3502:
+There is a **limit on the number of persistent `weak_map` variables** per island. In the standard environment, this limit is 4 persistent weak_maps. Exceeding this limit produces an error:
 
 <!--NoCompile-->
 <!-- 83 -->

--- a/docs/04_operators.md
+++ b/docs/04_operators.md
@@ -35,18 +35,18 @@ When multiple operators appear in the same expression, they are evaluated accord
 
 The precedence levels from highest to lowest are:
 
-| Precedence | Operators | Category | Format | Associativity |
-|------------|-----------|----------|--------|---------------|
-| 11 | `.`, `[]`, `()`, `{}`, `?` (postfix) | Member access, Indexing, Call, Construction, Query | Postfix | Left |
-| 10 | `-` (unary), `not` | Unary operations | Prefix | Right |
-| 9 | `*`, `/` | Multiplication, Division | Infix | Left |
-| 8 | `+`, `-` (binary) | Addition, Subtraction | Infix | Left |
-| 7 | `<`, `<=`, `>`, `>=` | Relational comparison | Infix | Right |
-| 5 | `and` | Logical AND | Infix | Left |
-| 4 | `or` | Logical OR | Infix | Left |
-| 3 | `..` | Range | Infix | Left |
-| 2 | ~~Lambda expressions~~ | ~~Function literals~~ (not yet supported) | Special | N/A |
-| 1 | `:=`, `=` | Assignment | Infix | Right |
+| Precedence | Operators | Category | Format | Associativity | Example |
+|------------|-----------|----------|--------|---------------|--|
+| 11 | `.`, `[]`, `()`, `{}`, `?` (postfix) | Member access, Indexing, Call, Construction, Query | Postfix | Left | `BossDefeated?`, `Player.Respawn()`|
+| 10 | `+`, `-` (unary), `not` | Unary operations | Prefix | Right | `+Score`, `-Distance`, `not HasCooldown?` |
+| 9 | `*`, `/` | Multiplication, Division | Infix | Left | `Score * Multiplier` |
+| 8 | `+`, `-` (binary) | Addition, Subtraction | Infix | Left | `X + Y`, `Health - Damage` |
+| 7 | `=` (relational), `<>`, `<`, `<=`, `>`, `>=` | Relational comparison | Infix | Right | `Player <> Target`, `Score > 100` |
+| 5 | `and` | Logical AND | Infix | Left | `HasPotion? and TryUsePotion[]` |
+| 4 | `or` | Logical OR | Infix | Left | `IsAlive? or Respawn()` |
+| 3 | `..` | Range | Infix | Left | `0..100`, `-15..50` |
+| 2 | ~~Lambda expressions~~ | ~~Function literals~~ (not yet supported) | Special | N/A | N/A |
+| 1 | `:=`, `set =` | Assignment | Infix | Right | `X := 15`, `set Y = 25` |
 
 ## Arithmetic Operators
 
@@ -140,7 +140,7 @@ if (Score > HighScore):
 if (Health <= 0.0):
     HandlePlayerDeath()
 
-# Equality with different types
+# Example with other comparable types
 if (PlayerName = "Admin"):
     EnableAdminMode()
 
@@ -394,7 +394,7 @@ Player := player_data {
 # Trailing commas are not allowed
 Config := game_config{
     MaxPlayers := 100,
-    EnablePvP := true # ,  -- not allowed
+    EnablePvP := true # ,  -- comma not allowed here
 }
 ```
 <!--verse

--- a/docs/05_mutability.md
+++ b/docs/05_mutability.md
@@ -491,6 +491,24 @@ Matrix[0] = array{666}
 Matrix[0][0] = 666
 ```
 
+**Important**: All nested levels should exist to use `set`, if any of the higher levels don't exist, the entire set will fail
+
+<!--versetest-->
+<!-- 24b -->
+```verse
+var Grid:[string][]int = map{"apples"=>array{1,2,3,4}}
+
+set Grid["bananas"] = array{} # ok - no nesting
+set Grid["apples"][2] = 7 # ok - changes nested array "3" to "7"
+
+set Grid["oranges"][0] = 10 # fail: "oranges" key not found in map
+
+# Alternative (make sure that higher levels exist first):
+if (not Grid["oranges"]):
+    set Grid["oranges"] = array{}
+set Grid["oranges"][0] = 10 # succeeds
+```
+
 #### Value Semantics for Collections
 
 Extracting a value from a mutable collection creates an independent copy:

--- a/docs/07_control.md
+++ b/docs/07_control.md
@@ -866,9 +866,9 @@ ProcessQuery()<transacts><decides>:void =
     for (Attempt := 1..5):
         if (Result := Query[ConnId]):
             ProcessResult(Result)
-            return  # defer executes before return  ## TODO CANT RETURN
+            return  # defer executes after return being called  ## TODO CANT RETURN
 
-    false  # defer executes before failure
+    # defer executes before leaving the function scope on success
 ```
 
 This is a subtle but crucial point: if a function fails due to
@@ -886,14 +886,13 @@ RiskyOperation(Id:int)<transacts><decides>:void={}
 ExampleWithFailure()<transacts><decides>:void =
     ResourceId := AcquireResource[]
     defer:
-        ReleaseResource(ResourceId)  # Scheduled...
+        ReleaseResource(ResourceId) # Scheduled...
 
-    if (false?):  # This fails!
-        RiskyOperation[ResourceId]
+    RiskyOperation[ResourceId] # This fails!
     # defer does NOT run - entire scope was speculative and rolled back
 ```
 
-When the `if (false)` fails, the entire function fails, and
+When the `RiskyOperation` fails, the entire function also fails, and
 speculative execution undoes everything—including the defer
 registration. The resource cleanup never happens because the resource
 acquisition itself is rolled back.

--- a/docs/07_control.md
+++ b/docs/07_control.md
@@ -855,10 +855,9 @@ ProcessFile(FileName:string)<transacts><decides>:void =
 Deferred code executes when the scope exits successfully or through
 explicit control flow like `return`:
 
-<!--NoCompile-->
 <!-- 62 -->
 ```verse
-ProcessQuery()<transacts><decides>:void =
+ProcessQuery()<transacts>:void =
     ConnId := OpenConnection()
     defer:
         CloseConnection(ConnId)  # Cleanup always needed
@@ -866,7 +865,7 @@ ProcessQuery()<transacts><decides>:void =
     for (Attempt := 1..5):
         if (Result := Query[ConnId]):
             ProcessResult(Result)
-            return  # defer executes after return being called  ## TODO CANT RETURN
+            return  # defer executes after return being called
 
     # defer executes before leaving the function scope on success
 ```

--- a/docs/09_structs_enums.md
+++ b/docs/09_structs_enums.md
@@ -336,7 +336,8 @@ GetWeekStartDecides(D:day)<decides>:string =
 
 **Open Enums Always Require Wildcard or `<decides>`:**
 
-Open enums can have new values added after publication, so they can never be exhaustive:
+Open enums can have new values added after publication, so they can never be exhaustive.\
+This is to ensure backwards compatibility of functions using them (see also [Publishing Functions](06_functions.md/#publishing-functions)):
 
 <!-- 16 -->
 ```verse
@@ -531,7 +532,7 @@ my_attribute := class(attribute):
     # category<constructor>(Name:string)<computes> := my_attribute{}
 
     # Apply to enum and enumerators
-@my_attribute()
+@my_attribute{}
 game_state := enum:
     @my_attribute(MyMetaData = "Initial")
     MainMenu

--- a/docs/12_access.md
+++ b/docs/12_access.md
@@ -393,7 +393,7 @@ implementation details to the wider codebase.
 
 ## Separating Read and Write Access
 
-An innovative features is the ability to apply different access
+An innovative feature is the ability to apply different access
 specifiers to reading and writing operations on the same
 variable. This fine-grained control allows you to create variables
 that are widely readable but narrowly writable, implementing common
@@ -422,8 +422,8 @@ The syntax places the write-access specifier on the `var` keyword and
 the read-access specifier on the identifier itself. This visual
 separation makes the access levels immediately clear when reading
 code. The write specifier must be at least as restrictive as the read
-specifier—you cannot have a variable that's privately readable but
-publicly writable, as this would violate basic encapsulation
+specifier — you cannot write to a variable that's privately readable
+but publicly writable, as this would violate basic encapsulation
 principles.
 
 ## Best Practices
@@ -478,6 +478,9 @@ compilation and evolution.
 ### Built-in Annotations
 
 #### @deprecated
+
+!!! warning "Internal Feature"
+    @deprecated attribute is currently an internal feature and cannot be used by end-users.
 
 The `@deprecated` annotation marks definitions that should no longer
 be used. When code references a deprecated definition, the compiler
@@ -552,6 +555,9 @@ The `@deprecated` annotation can be applied to:
 - Modules
 
 #### @experimental
+
+!!! warning "Internal Feature"
+    @deprecated attribute is currently an internal feature and cannot be used by end-users.
 
 The `@experimental` annotation marks features that are not yet stable
 and may change or be removed in future versions. Experimental features
@@ -765,8 +771,7 @@ Constraints on accessors:
 - Not all types are supported for accessor fields
 - Accessor fields are currently only allowed in epic_internal scopes
 
-For more details on accessor patterns, see the "Fields with Accessors"
-section in the Interfaces documentation.
+For more details on accessor patterns, see [Fields with Accessors](10_classes_interfaces.md).
 
 ### Localization
 
@@ -934,7 +939,7 @@ base_ui := class:
 
 derived_ui := class(base_ui):
     # Override the title message
-    (base_ui:)Title<localizes><override>:message = "Derived Title"
+    Title<localizes><override>:message = "Derived Title"
     # Inherits Description from base
 ```
 
@@ -1029,7 +1034,9 @@ Localized messages support standard access specifiers:
 my_module := module:
     PublicMessage<localizes><public> : message = "Public message"
     InternalMessage<localizes> : message = "Internal message"
-    # PrivateMessage<localizes><private> : message = "Private message"  # private not allowed in modules
+
+    some_class := class:
+        PrivateMessage<localizes><private> : message = "Private message"  # private not allowed in module scopes
 ```
 
 #### Best Practices

--- a/docs/13_effects.md
+++ b/docs/13_effects.md
@@ -99,8 +99,8 @@ The six effect families are:
 * **Internal**: Reserved for internal use
 
 Some effects have no specifier, while some specifiers imply multiple
-effects. For instance, `<transacts>` implies `reads`, `writes`, and
-`allocates`, and belongs to both the Heap family.
+effects. For instance, `<transacts>` implies `reads`, `writes` and
+`allocates`, and belongs to the Heap family.
 
 Effect specifiers can be further divided into *exclusive* specifiers
 (`<converges>`, `<computes>`, `<transacts>`) and *additive* specifiers
@@ -112,20 +112,20 @@ error (cannot have two exclusive effects).
 
 |Fundamental Effect|Effect Specifier|Effect Family|Effects implied by Specifier | Notes |
 | -----        | -----------    | -------     | ----- | ---- |
-| **succeeds** |                | Cardinality |                  | *No specifier* |
-| **fails**    |                | Cardinality |                  | *No specifier* |
+| **succeeds** |                | Cardinality |                  | *No specifier; Can Succeed* |
+| **fails**    |                | Cardinality |                  | *No specifier; Can Fail* |
 |              | `<decides>`    | Cardinality | `{succeeds, fails}` | *Cannot combine with `<suspends>`* |
-| **reads**    | `<reads>`      | Heap        | `{reads}`        | |
-| **writes**   | `<writes>`     | Heap        | `{writes}`       | |
-| **allocates**| `<allocates>`  | Heap        | `{allocates}`    | |
-|              | `<transacts>`  | Heap        | `{reads, writes, allocates}` | *Exclusive* |
-|              | `<computes>`   | Heap        | `{}`             | *Exclusive; default* |
+| **reads**    | `<reads>`      | Heap        | `{reads}`        | *Allows reading mutable states* |
+| **writes**   | `<writes>`     | Heap        | `{writes}`       | *Allows writing mutable states* |
+| **allocates**| `<allocates>`  | Heap        | `{allocates}`    | *Allows memory allocation* |
+|              | `<transacts>`  | Heap        | `{reads, writes, allocates}` | *Exclusive; default* |
+|              | `<computes>`   | Heap        | `{}`             | *Exclusive; Pure computation* |
 | **suspends** | `<suspends>`   | Suspension  | `{suspends}`     | *Cannot combine with `<decides>`* |
-| **diverges** |                | Divergence  | `{diverges}`     | *No specifier* |
-|              | `<converges>`  | Divergence  | `{}`             | *Native functions only and Exclusive* |
-| **dictates** |                | Prediction  | `{dictates}`     | *No specifier* |
-|              | `<predicts>`   | Prediction  | `{}`             | |
-| **no_rollback** |             | Internal    | `{no_rollback}`  | *To be deprecated* |
+| **diverges** |                | Divergence  | `{diverges}`     | *No specifier; May run forever* |
+|              | `<converges>`  | Divergence  | `{}`             | *Exclusive; Native functions only* |
+| **dictates** |                | Prediction  | `{dictates}`     | *No specifier; Server Authority* |
+|              | `<predicts>`   | Prediction  | `{}`             | *Allows Client Prediction* |
+| **no_rollback** |             | Internal    | `{no_rollback}`  | *To be deprecated; Transactions disallowed* |
 
 The following restrictions are in effect:
 
@@ -209,8 +209,8 @@ ValidateHealth(Health:float)<transacts><decides>:void =
 
 # Usage
 if (ValidateHealth[Player.Health]):
-# Health is valid, continue processing
-StartCombat()
+    # Health is valid, continue processing
+    StartCombat()
 ```
 <!--verse
 #>
@@ -381,7 +381,8 @@ forms creates ambiguity about what's being handled.
 
 #### Prediction effects
 
-**[Pre-release]**: The `<predicts>` effect is not yet released.
+!!! note "Unreleased Feature"
+    The `<predicts>` effect is not yet released.
 
 The prediction family determines where code runs in a client-server
 architecture. By default, functions have the `dictates` effect,

--- a/docs/13_effects.md
+++ b/docs/13_effects.md
@@ -112,12 +112,12 @@ error (cannot have two exclusive effects).
 
 |Fundamental Effect|Effect Specifier|Effect Family|Effects implied by Specifier | Notes |
 | -----        | -----------    | -------     | ----- | ---- |
-| **succeeds** |                | Cardinality |                  | *No specifier; Can Succeed* |
+| **succeeds** |                | Cardinality |                  | *No specifier; Must Succeed* |
 | **fails**    |                | Cardinality |                  | *No specifier; Can Fail* |
 |              | `<decides>`    | Cardinality | `{succeeds, fails}` | *Cannot combine with `<suspends>`* |
 | **reads**    | `<reads>`      | Heap        | `{reads}`        | *Allows reading mutable states* |
 | **writes**   | `<writes>`     | Heap        | `{writes}`       | *Allows writing mutable states* |
-| **allocates**| `<allocates>`  | Heap        | `{allocates}`    | *Allows memory allocation* |
+| **allocates**| `<allocates>`  | Heap        | `{allocates}`    | *Allows allocation of mutable memory* |
 |              | `<transacts>`  | Heap        | `{reads, writes, allocates}` | *Exclusive; default* |
 |              | `<computes>`   | Heap        | `{}`             | *Exclusive; Pure computation* |
 | **suspends** | `<suspends>`   | Suspension  | `{suspends}`     | *Cannot combine with `<decides>`* |

--- a/docs/14_concurrency.md
+++ b/docs/14_concurrency.md
@@ -660,25 +660,25 @@ A task moves through several distinct states during its lifetime:
 yet finished. It's still doing work or waiting to resume.
 
 **Completed**: The task finished successfully and returned a
-result. Once completed, a task never changes state again.
+result. Once completed, a task never changes state again. (Terminal state)
 
 **Canceled**: The task was canceled before it could complete. This is
-a terminal state—canceled tasks cannot resume.
+a terminal state — canceled tasks cannot resume.
 
 **Settled**: A task is settled if it has reached either the Completed
-or Canceled state. Settled tasks are no longer executing.
+or Canceled state. Settled tasks are no longer executing. (Terminal state)
 
 **Uninterrupted**: A task is uninterrupted if it completed
 successfully without being canceled. This is equivalent to the
-Completed state.
+Completed state. (alias)
 
 **Interrupted**: A task is interrupted if it was canceled. This is
-equivalent to the Canceled state.
+equivalent to the Canceled state. (alias)
 
-### Cancel()
+### Task.Cancel()
 
-!!! note
-    The Cancel method has not be released at this time.
+!!! note "Unreleased Feature"
+    The Cancel() method has not be released at this time.
 	
 The `Cancel()` method requests cancellation of a task. This is a safe
 operation that can be called on any task in any state:
@@ -716,7 +716,7 @@ Calling `Cancel()` on an already completed task is safe and has no
 effect. This means you can cancel tasks without worrying about race
 conditions between completion and cancellation.
 
-### Await()
+### Task.Await()
 
 The `Await()` method suspends the calling context until the task
 completes, then returns the task's result:
@@ -745,7 +745,7 @@ Print("Task returned: {Result}")
 - **Blocks until completion**: If the task is still running, `Await()`
   suspends until it finishes
 - **Returns immediately if complete**: If the task already finished,
-  `Await()` returns the cached result instantly
+  `Await()` returns the cached result instantly (Sticky)
 - **Can be called multiple times**: You can await the same task
   repeatedly, always getting the same result
 - **Propagates cancellation**: If the awaited task was canceled,
@@ -966,8 +966,8 @@ UseResourceSafely()<suspends>:void =
 **Key defer: behaviors:**
 
 1. **Always executes on scope exit**: Whether the function returns normally, fails, or is canceled, the defer block runs
-2. **Runs in reverse order**: Multiple defer blocks execute in
-   last-in-first-out order (most recent defer runs first)
+2. **Runs in reverse order**: Multiple defer blocks execute in LIFO
+   order (last-in-first-out - most recent defer runs first)
 3. **Captures current scope**: defer blocks close over variables from
    the enclosing scope
 4. **Cannot be suspended**: defer blocks must execute immediately and
@@ -1102,15 +1102,14 @@ finalization.
 
 defer blocks belong to their enclosing function scope and execute when that function exits:
 
-<!--verse
-HelperFunction():void={
+<!--verse -->
+<!-- 45 -->
+```verse
+HelperFunction():void =
     defer:
         Print("Helper defer")
     Print("In helper")
-}
--->
-<!-- 45 -->
-```verse
+
 OuterFunction()<suspends>:void =
     defer:
         Print("Outer defer")
@@ -1173,6 +1172,9 @@ tasks remain responsive to cancellation and share execution time
 fairly with other concurrent operations.
 
 ### NextTick()
+
+!!! note "Unreleased Feature"
+    NextTick() have not yet been released. 
 
 The `NextTick()` function suspends execution until the next simulation
 update (tick). Unlike `Sleep(0.0)` which yields control and may resume
@@ -1535,7 +1537,7 @@ operations, enabling communication without shared mutable state.
 
 The `event(t)` type creates a communication channel where producers
 signal values and consumers await them. Each signal delivers one value
-to one awaiting task:
+to each awaiting task:
 
 <!--versetest
 ProcessValue(:int):void={}
@@ -1623,6 +1625,9 @@ Result := race:
 
 ### Sticky Events
 
+!!! note "Unreleased Feature"
+    Sticky Events have not yet been released and is not currently available.
+
 While basic events deliver each signal to exactly one awaiter,
 `sticky_event(t)` remembers the last signaled value and delivers it to
 all subsequent awaits until a new value is signaled:
@@ -1663,6 +1668,9 @@ just changed?".
 
 ### Subscribable Events
 
+!!! note "Unreleased Feature"
+    Subscribable Events have not yet been released and is not currently available.
+
 The `subscribable_event` type implements the observer pattern,
 allowing multiple handlers to react to each signal. Unlike events
 where awaiting tasks explicitly wait, subscribable events let you
@@ -1676,7 +1684,7 @@ CheckAchievements(:int):void={}
 -->
 <!-- 63 -->
 ```verse
-ScoreEvent := subscribable_event_intrnl(int){}
+ScoreEvent := subscribable_event(int){}
 
 # Subscribe multiple handlers
 Logger := ScoreEvent.Subscribe(LogScore)
@@ -1719,7 +1727,7 @@ signalable(t:type) := interface:
 ```
 
 The `awaitable` interface represents anything that can be waited on,
-while `signalable` represents anything that can receive signals. By
+while `signalable` represents anything that can send signals. By
 separating these capabilities, Verse enables precise control over who
 can produce values versus who can consume them.
 
@@ -1760,7 +1768,7 @@ Handler(:int):void={}
 -->
 <!-- 66 -->
 ```verse
-MyEvent := subscribable_event_intrnl(int){}
+MyEvent := subscribable_event(int){}
 
 # Subscription in a failing transaction
 if:
@@ -1778,7 +1786,7 @@ Handler(:int):void={}
 -->
 <!-- 67 -->
 ```verse
-MyEvent := subscribable_event_intrnl(int){}
+MyEvent := subscribable_event(int){}
 Sub := MyEvent.Subscribe(Handler)
 
 # Cancel in a failing transaction
@@ -1853,7 +1861,7 @@ LogItemPickup(:int):void={}
 -->
 <!-- 70 -->
 ```verse
-ItemPickedUp := subscribable_event_intrnl(int){}
+ItemPickedUp := subscribable_event(int){}
 
 # Each system subscribes independently
 InitializeSystems():void =

--- a/docs/16_modules.md
+++ b/docs/16_modules.md
@@ -230,18 +230,18 @@ utilities := module:
     Calculate(X:int):int = X * 2
 
     # Classes, interfaces, structs
-    data_class:= class:
+    data_class := class:
         Value:int
 
-    data_interface:= interface:
+    data_interface := interface:
         GetValue():int
 
-    data_struct:= struct:
+    data_struct := struct:
         X:float
         Y:float
 
     # Enums
-    status:= enum:
+    status := enum:
         Active
         Inactive
 
@@ -250,7 +250,10 @@ utilities := module:
         NestedFunction():void = {}
 
     # Type aliases
-    coordinate:= tuple(float, float)
+    coordinate := tuple(float, float)
+
+    # Refinement types
+    positive_int := type{X:int where X > 0}
 ```
 
 Unlike functions, classes, or data values, modules are not first-class
@@ -313,8 +316,8 @@ explicitness helps prevent naming conflicts and makes dependencies
 clear.
 
 The `using` statement is the primary mechanism for importing modules
-into your Verse code. It appears at the top of your file, before any
-other code definitions, and makes the contents of the specified module
+into your Verse code. It usually is placed at the top of your file, before
+any other code definitions, and makes the contents of the specified module
 available in your current scope.
 
 The basic syntax is straightforward - the keyword `using` followed by
@@ -507,8 +510,8 @@ using { /GameB/Combat }
 # Both modules might define CalculateDamage
 # You must use qualified names:
 DamageA := Combat.CalculateDamage(10.0)  # Error: ambiguous
-DamageA := /GameA/Combat.CalculateDamage(10.0)  # OK: fully qualified
-DamageB := /GameB/Combat.CalculateDamage(10.0)  # OK: fully qualified
+DamageA := (/GameA/Combat:)CalculateDamage(10.0)  # OK: fully qualified
+DamageB := (/GameB/Combat:)CalculateDamage(10.0)  # OK: fully qualified
 ```
 
 ### Qualified Names
@@ -735,7 +738,7 @@ my_class := class:
     var Value<public>:int = 0
     block:
         (local:)Value:int = 42
-        set (/PackagePath/my_class:)Value = (local:)Value
+        set (my_class:)Value = (local:)Value
 ```
 
 The `(local:)` qualifier **cannot** be used in these contexts (all produce error 3612):
@@ -919,11 +922,11 @@ using { /Verse.org/Random }
     (/Verse.org/Random:)GetRandomFloat(0.0, 1.0)
 ```
 
-The compiler resolves `GetRandomFloat` to `/Verse.org/Random:GetRandomFloat` based on the `using` statement.
+The compiler resolves `GetRandomFloat` to `(/Verse.org/Random:)GetRandomFloat` based on the `using` statement.
 
 ### When It Matters
 
-You rarely need to think about automatic qualification during normal
+You rarely need to think about automatic or manual qualification during normal
 development, as the compiler handles it transparently. However,
 understanding it helps in several situations:
 
@@ -1208,11 +1211,11 @@ When working with modules, you may encounter various issues. Understanding these
 <!--NoCompile-->
 <!-- 54 -->
 ```verse
-   # Wrong: different case
-   using { /verse.org/random }  # Error: module not found
+# Wrong: different case
+using { /verse.org/random }  # Error: module not found
 
-   # Correct: proper case
-   using { /Verse.org/Random }  # Works
+# Correct: proper case
+using { /Verse.org/Random }  # Works
 ```
 
 2. **Missing parent module import**: When importing nested modules, ensure the parent is imported first.
@@ -1220,13 +1223,13 @@ When working with modules, you may encounter various issues. Understanding these
 <!--NoCompile-->
 <!-- 55 -->
 ```verse
-   # Wrong: child before parent
-   using { inventory }  # Error if inventory is nested
+# Wrong: child before parent
+using { inventory }  # Error if inventory is nested
 
-   # Correct: parent first
-   using { game_systems }
-   using { inventory }
- ```
+# Correct: parent first
+using { game_systems }
+using { inventory }
+```
 
 3. **File location mismatch**: Ensure your file structure matches your module structure. If you have a folder named `player_systems`, all files in that folder are part of the `player_systems` module.
 
@@ -1240,33 +1243,33 @@ When working with modules, you may encounter various issues. Understanding these
 
 <!--NoCompile-->
 <!-- 56 -->
- ```verse
-   # In module_a
-   SecretValue:int = 42  # Internal by default
-   PublicValue<public>:int = 100  # Explicitly public
+```verse
+# In module_a
+SecretValue:int = 42  # Internal by default
+PublicValue<public>:int = 100  # Explicitly public
 
-   # In another module
-   using { module_a }
-   X := module_a.SecretValue  # Error: not accessible
-   Y := module_a.PublicValue  # Works
- ```
+# In another module
+using { module_a }
+X := module_a.SecretValue  # Error: not accessible
+Y := module_a.PublicValue  # Works
+```
 
 2. **Protected or private members**: These are not accessible outside their defining scope.
 
 <!--NoCompile-->
 <!-- 57 -->
- ```verse
-   # In a class
-   class_a := class:
-       PrivateField<private>:int = 10
-       ProtectedField<protected>:int = 20
-       PublicField<public>:int = 30
+```verse
+# In a class
+class_a := class:
+    PrivateField<private>:int = 10
+    ProtectedField<protected>:int = 20
+    PublicField<public>:int = 30
 
-   # Outside the class
-   Obj := class_a{}
-   X := Obj.PrivateField  # Error: private
-   Y := Obj.PublicField   # Works
- ```
+# Outside the class
+Obj := class_a{}
+X := Obj.PrivateField  # Error: private
+Y := Obj.PublicField   # Works
+```
 
 ### Circular Dependency Errors
 

--- a/docs/17_persistable.md
+++ b/docs/17_persistable.md
@@ -116,8 +116,8 @@ day := enum<persistable>:
 
 Important notes:
 
-- Closed persistable enums cannot be changed to open after publication
-- Open persistable enums can have new values added after publication
+- `<closed>` persistable enums cannot be changed to open after publication
+- Only `<open>` persistable enums can have new values added after publication
 
 ## Prohibited Field Types
 
@@ -195,6 +195,9 @@ GetOrCreatePlayerStats(Player : player) : player_stats =
 
 
 ## JSON Serialization
+
+!!! note "Unreleased Feature"
+    JSON Serialization have not yet been released and is not publicly available.
 
 Verse provides JSON serialization functions for persistable types,
 enabling manual serialization and deserialization of data. While the

--- a/docs/18_evolution.md
+++ b/docs/18_evolution.md
@@ -25,7 +25,7 @@ Backward compatibility in Verse goes beyond simple syntactic preservation—it e
 
 Function effects exemplify this approach. When a function is published with specific effects like `<reads>`, indicating it may read mutable heap data, this becomes part of its contract. Future versions of the function can have fewer effects—evolving from `<reads>` to `<computes>`—but never more. This restriction ensures that code depending on the function's effect profile continues to work correctly, as the function only becomes more pure, never less.
 
-Type evolution follows similar principles. Types can become more specific over time, such as changing from `int` to `nat`, as this represents a refinement rather than a fundamental change. Structures must maintain all existing fields, though new fields can be added. Classes marked with `<final_super>` commit to their inheritance hierarchy permanently, ensuring that code relying on specific inheritance relationships remains valid.
+Type evolution follows similar principles. Types can become more specific over time, such as changing from `rational` to `int`, as this represents a refinement rather than a fundamental change. Structures must maintain all existing fields, though new fields can be added. Classes marked with `<final_super>` commit to their inheritance hierarchy permanently, ensuring that code relying on specific inheritance relationships remains valid.
 
 The enforcement of these rules happens at publication time, not just at compile time. Verse actively prevents developers from publishing updates that would violate compatibility guarantees, turning what might be runtime failures in other systems into publication-time errors that must be resolved before code can be deployed.
 


### PR DESCRIPTION
The MKDocs plugin `mkdocs-git-revision-date-localized-plugin` requires additional config to track last commits individually per-file instead of globally for the repository

+ Added Checkout config for track commits per file
+ Set per file commit tracking only on the files under /docs folder