### PR TITLE
Clarify the evolution of transparent and computes functions

### DIFF
--- a/docs/06_functions.md
+++ b/docs/06_functions.md
@@ -2049,24 +2049,38 @@ the function and its clients. Consider this function:
 
 <!-- 139 -->
 ```verse
-F1<public>(X:int)<computes>:int = X + 1
+F1<public>(X:int):int = X + 1
 ```
 
-The type annotation (`X:int)<computes>:int`) tells us that this
-function promises that given any integer it will always return an
-integer and that it perfoms no heap effects. That contract cannot be
-broken in future versions of the code. The implementation could change
-in the future, perhaps to perform additional operations or
-optimizations, as long as it maintains its signature.
+The type annotation (`X:int):int`) tells us that this function promises that
+given any integer it will always return an integer. That contract cannot be
+broken in future versions of the code. Because it has the default effect, which
+includes the `<reads>` effect, the implementation could change in the future,
+perhaps to perform additional operations or optimizations, as long as it
+maintains its signature.
 
-Functions such as `F1` are sometimes called *opaque* as the return
-type abstracts the funtion's body. Future version of Verse will 
-support *transparent* functions:
+Functions that do not have the `<reads>` effect are less flexible. Consider
+this function:
 
-<!--NoCompile-->
 <!-- 140 -->
 ```verse
-F2<public>(X:int)<computes>:= X + 1
+F2<public>(X:int)<computes>:int = X + 1
+```
+
+Because it has the `<computes>` effect specifier, it does not have the
+`<reads>` effect. Without the `<reads>` effect, this function promises to
+always return the same result for some given parameters. Changing it to return,
+for example, `X + 2` would break that promise, and so must be rejected by the
+compiler as backward incompatible.
+
+Functions such as `F1` and `F2` are sometimes called *opaque* as the return
+type abstracts the function's body. Future version of Verse will support
+*transparent* functions:
+
+<!--NoCompile-->
+<!-- 141 -->
+```verse
+F2<public>(X:int) := X + 1
 ```
 
 A transparent function does not declare its return type, instead the

--- a/docs/18_evolution.md
+++ b/docs/18_evolution.md
@@ -195,6 +195,12 @@ For **non-final instance methods**:
 - **Cannot convert between normal functions and constructors.** These are fundamentally different callable entities with different calling conventions.
 - **Cannot convert between functions and parametric types.** A function cannot become a type parameter or vice versa.
 
+**Function body:**
+
+- **Cannot change the body of transparent functions.** Verification of callers might depend on the function body of transparent functions, so changes could break callers.
+- **Cannot change the body of opaque functions without the `<reads>` effect.** This is to ensure that `NonReadsFunction()=NonReadsFunction()` even when code is evolving.
+- **Can change the body of opaque functions that have the `<reads>` effect.** Code evolution can be observed by the `<reads>` effect.
+
 **Understanding Variance:**
 
 The asymmetry in these rules reflects **variance** in type theory:


### PR DESCRIPTION
Transparent functions cannot evolve in a way that would affect verification of callers, and since verification of calls to transparent functions can depend on the body of the transparent function, this means that, conservatively, the body of the function cannot change.
Opaque functions that lack the reads effect cannot evolve because the reads effect is required to observe evolution of code.