### PR TITLE
Exclude VerseSyntaxValidation.md from search

### DIFF
--- a/docs/VerseSyntaxValidation.md
+++ b/docs/VerseSyntaxValidation.md
@@ -1,3 +1,7 @@
+---
+search:
+  exclude: true
+---
 Use this to test and validate syntax highlighting
 
 #### Basics


### PR DESCRIPTION
I don‘t think this is a useful page for users, right?