### PR TITLE
Fixed broken links to references

### DIFF
--- a/docs/01_expressions.md
+++ b/docs/01_expressions.md
@@ -329,7 +329,7 @@ The `logic{}` expression requires at least a superficial possibility of failure.
 Valid := logic{false?}               # OK: false? can fail
 ```
 
-Multiple expressions inside `logic{}` can be separated by semicolons or commas (see [Semicolons vs Commas](#semicolons-vs-commas-sequences-and-tuples) for details):
+Multiple expressions inside `logic{}` can be separated by semicolons or commas (see [Semicolons vs Commas](#semicolons-vs-commas) for details):
 
 <!--versetest-->
 <!-- 19 -->
@@ -880,7 +880,7 @@ for (I := 0..Count):  # Must use := syntax, not :
 
 Ranges are not first-class values. They cannot be stored in variables
 or used outside of `for` loop iteration clauses. See the [Range
-Operator Restrictions](07_control.md#range-operator-restrictions)
+Operator Restrictions](07_control.md#for-expressions)
 section for details.
 
 ### Logical Operations
@@ -1356,7 +1356,7 @@ block:
 Expressions within a compound can be separated by semicolons, commas,
 or newlines. Semicolons and newlines create sequences (returning the
 last value), while commas create tuples. See [Semicolons vs
-Commas](#semicolons-vs-commas-sequences-and-tuples) for the complete
+Commas](#semicolons-vs-commas) for the complete
 rules:
 
 <!--versetest

--- a/docs/03_containers.md
+++ b/docs/03_containers.md
@@ -139,7 +139,7 @@ G():void =
 
 Tuples also play a role in structured concurrency. The `sync` expression produces a tuple of results, allowing several computations that unfold over time to be evaluated simultaneously. In this way, tuples provide not only a convenient grouping mechanism but also a foundation for composing concurrent computations.
 
-Tuples can also be automatically converted to arrays when used with array concatenation operators `+` and `+=`. See [Tuples with Array Operators](#tuples-with-array-operators) for more details.
+Tuples can also be automatically converted to arrays when used with array concatenation operators `+` and `+=`. See [From Tuples to Arrays](#from-tuples-to-arrays) for more details.
 
 ## Arrays
 

--- a/docs/11_types.md
+++ b/docs/11_types.md
@@ -1269,7 +1269,7 @@ as map keys, including:
 
 Note that while `float` can be used as a map key, floating-point
 special values have specific equality semantics (see [Map
-documentation](02_primitives.md#floating-point-keys) for details on
+documentation](02_primitives.md#floats) for details on
 `NaN` and zero handling).
 
 There is currently no way to make a regular class comparable by


### PR DESCRIPTION
This commit corrects reference links used in different sections to get as close as possible to the relevant documentation.

Testing Performed:
Build the site locally on windows and tested it using the `mkdocs serve`