### PR TITLE
Fixed misplaced comment in the Mutability section

### DIFF
--- a/docs/05_mutability.md
+++ b/docs/05_mutability.md
@@ -28,11 +28,11 @@ point := struct<computes>:
     X:float = 0.0
     Y:float = 0.0
 
+# These values are eternal - Origin will always be (0, 0)
 Origin := point{}
 UnitX := point{X := 1.0}
 UnitY := point{Y := 1.0}
 
-# These values are eternal - Origin will always be (0, 0)
 Distance(P1:point, P2:point)<reads>:float =
     DX := P2.X - P1.X
     DY := P2.Y - P1.Y

--- a/docs/06_functions.md
+++ b/docs/06_functions.md
@@ -72,13 +72,13 @@ After the first named parameter, all subsequent parameters must also be named:
 
 <!--versetest
 assert_semantic_error(3629):
-    Invalid(? Named:int, Positional:string):void = {}
+    Invalid(?Named:int, Positional:string):void = {}
 <#
 -->
 <!-- 04-->
 ```verse
 # Invalid: named followed by positional
-Invalid(? Named:int, Positional:string):void = {}  # ERROR
+Invalid(?Named:int, Positional:string):void = {}  # ERROR
 ```
 <!-- #>-->
 


### PR DESCRIPTION
The code snippet showcased to introduce Immutable Values and Structures had a comment misplaced on a function instead of the values it was talking about.
