### PR TITLE
Fixed an invalid code snippet in Classes and Interface Section

### DIFF
--- a/docs/10_classes_interfaces.md
+++ b/docs/10_classes_interfaces.md
@@ -303,12 +303,12 @@ character := class:
         LogCharacterAction(Self, "announced")
 
 
-    SetOption(Key:string, Value:string):builder =
+    SetOption(Key:string, Value:string):character =
         set Config[Key] = Value
         Self  # Return this instance for method chaining
 
 
-    SetName(NewName:stirng):void =
+    SetName(NewName:string):void =
        set Self.Name = NewName	  # Set the name of this instance
 	   Self.Announce()            # Call a method of this instance
 ```


### PR DESCRIPTION
- Fixed the return type of the function illustrating builder pattern that was returning an invalid type.
- Fixed the misspelled 'string' in one of the function parameters.