### PR TITLE
Fix typo in experimental attribute warning

### DIFF
--- a/docs/12_access.md
+++ b/docs/12_access.md
@@ -672,7 +672,7 @@ The `@deprecated` annotation can be applied to:
 #### @experimental
 
 !!! warning "Internal Feature"
-    @deprecated attribute is currently an internal feature and cannot be used by end-users.
+    @experimental attribute is currently an internal feature and cannot be used by end-users.
 
 The `@experimental` annotation marks features that are not yet stable
 and may change or be removed in future versions. Experimental features


### PR DESCRIPTION
Fixes a typo in the `@experimental` section.

The warning currently says "`@deprecated` attribute", but the section is about `@experimental`.