### PR TITLE
docs: fix broken link, incorrect examples, and extraction markers

### DIFF
--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -372,7 +372,7 @@ This example showcases Verse in a practical context. Let's explore what makes th
 
 **Type System and Data Modeling**
 
-The example begins with Verse's rich type system. Types flow naturally through the code; many type annotations are omitted as they can be infered. When we do specify types, like `Items:[]game_item`, they document intent rather than just satisfy the compiler. The `item_rarity` enum provides type-safe constants without the boilerplate of traditional enumerations. The `item_stats` struct marked as `<persistable>` can be saved and loaded from persistent storage, essential for game saves. The `game_item` class uses `<unique>` to ensure reference equality semantics.  
+The example begins with Verse's rich type system. Types flow naturally through the code; many type annotations are omitted as they can be inferred. When we do specify types, like `Items:[]game_item`, they document intent rather than just satisfy the compiler. The `item_rarity` enum provides type-safe constants without the boilerplate of traditional enumerations. The `item_stats` struct marked as `<persistable>` can be saved and loaded from persistent storage, essential for game saves. The `game_item` class uses `<unique>` to ensure reference equality semantics.  
 
 **Failure as Control Flow**
 

--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -221,7 +221,7 @@ item_stats := struct<persistable>:
     Value:int = 0
 
 # Class for game items - object-oriented features with functional constraints
-game_item := class<final><unique><persistable>:
+game_item := class<final><persistable>:
     Name:string
     Rarity:item_rarity = item_rarity.common
     Stats:item_stats = item_stats{}
@@ -372,7 +372,7 @@ This example showcases Verse in a practical context. Let's explore what makes th
 
 **Type System and Data Modeling**
 
-The example begins with Verse's rich type system. Types flow naturally through the code; many type annotations are omitted as they can be inferred. When we do specify types, like `Items:[]game_item`, they document intent rather than just satisfy the compiler. The `item_rarity` enum provides type-safe constants without the boilerplate of traditional enumerations. The `item_stats` struct marked as `<persistable>` can be saved and loaded from persistent storage, essential for game saves. The `game_item` class uses `<unique>` to ensure reference equality semantics.  
+The example begins with Verse's rich type system. Types flow naturally through the code; many type annotations are omitted as they can be inferred. When we do specify types, like `Items:[]game_item`, they document intent rather than just satisfy the compiler. The `item_rarity` enum provides type-safe constants without the boilerplate of traditional enumerations. The `item_stats` struct marked as `<persistable>` can be saved and loaded from persistent storage, essential for game saves. The `game_item` class is marked `<final>` and `<persistable>` so its instances can be saved and restored; because persistable data is serialized by value, such classes cannot also be `<unique>`.  
 
 **Failure as Control Flow**
 

--- a/docs/01_expressions.md
+++ b/docs/01_expressions.md
@@ -732,9 +732,8 @@ loop {
 
 The loop construct can use indented syntax for clarity.
 
-A loop expression produces a value of type `true` (the
-top type in Verse's type system), regardless of what expressions appear in
-its body. This value is currently not useful for practical purposes—you
+A loop expression produces a value of type `true`, regardless of what
+expressions appear in its body. This value is currently not useful for practical purposes—you
 typically use loops for their side effects rather than their return value.
 
 ```verse

--- a/docs/02_primitives.md
+++ b/docs/02_primitives.md
@@ -633,7 +633,7 @@ Dividend = Quotient[Dividend, Divisor] * Divisor + Mod[Dividend, Divisor]
 
 The sign of the result follows specific rules:
 
-- `Mod` result has the same sign as the divisor (Euclidean division)
+- `Mod` result is always non-negative, in the range `0 <= Result < |Divisor|` (Euclidean division)
 - `Quotient` adjusts accordingly to maintain the identity
 
 There are also some utility functions:

--- a/docs/03_containers.md
+++ b/docs/03_containers.md
@@ -231,7 +231,7 @@ Example : [][]int =
             Row * Column
 ```
 
-produces a triangular array with rows of increasing length: row 0 has none, row 1 has a single `0`, row 2 has `0, 2, 4`, and row 3 has `0, 3, 6, 9`.
+produces a triangular array with rows of increasing length: row 0 has a single `0`, row 1 has `0, 1`, row 2 has `0, 2, 4`, and row 3 has `0, 3, 6, 9`.
 
 Nested arrays with complex initialization work naturally as class field defaults:
 

--- a/docs/06_functions.md
+++ b/docs/06_functions.md
@@ -1269,7 +1269,7 @@ Process(X:int):string =
 
     "{IntResult}, {FloatResult}"
 
-Process(1)  # Returns "Int: 42, Float: 3.14"
+Process(1)  # Returns "int: 42, float: 3.14"
 ```
 
 Overload resolution works the same as for top-level functions.

--- a/docs/07_control.md
+++ b/docs/07_control.md
@@ -411,7 +411,7 @@ in the if-expression. The assignment `set B = ...` uses the value of
 the if-expression, showing that `break` is compatible in any type context.
 
 **Loop Return Value:** The loop expression itself produces a value of type
-`true` (the top type), regardless of what expressions appear in its body.
+`true`, regardless of what expressions appear in its body.
 This return value is rarely useful in practice—loops are typically used for
 their side effects.
 

--- a/docs/07_control.md
+++ b/docs/07_control.md
@@ -546,7 +546,7 @@ Doubled := for (X := 1..5, Y := X * 2):
 
 # Combine with filtering
 SafeDivision := for (X := -3..3, X <> 0, Y := Floor[10.0 / (X*1.0)]):
-    Y  # Skips X=0, returns array{-3, -5, -10, 10, 5, 3}
+    Y  # Skips X=0, returns array{-4, -5, -10, 10, 5, 3}
 ```
 
 These intermediate variables are scoped to the iteration and can

--- a/docs/09_structs_enums.md
+++ b/docs/09_structs_enums.md
@@ -432,7 +432,7 @@ GetWeekStartDecides(D:day)<decides>:string =
 **Open Enums Always Require Wildcard or `<decides>`:**
 
 Open enums can have new values added after publication, so they can never be exhaustive.\
-This is to ensure backwards compatibility of functions using them (see also [Publishing Functions](06_functions.md/#publishing-functions)):
+This is to ensure backwards compatibility of functions using them (see also [Publishing Functions](06_functions.md#publishing-functions)):
 
 <!--NoCompile-->
 <!-- 16 -->

--- a/docs/10_classes_interfaces.md
+++ b/docs/10_classes_interfaces.md
@@ -1823,7 +1823,7 @@ player := class(entity):
 consumer(t:type) := class:
     Process(Item:t):void = {}
 -->
-<!-- 54-->
+<!-- 541-->
 ```verse
 # Contravariance allows supertype → subtype
 EntityConsumer:consumer(entity) = consumer(entity){}
@@ -2826,7 +2826,7 @@ player_component := class(advanced_component):
     Update<override>():void = {}
     AdvancedUpdate<override>():void = {}
 -->
-<!-- 104-->
+<!-- 1041-->
 ```verse
 C1 := player_component{}
 C2 := player_component{}
@@ -2863,7 +2863,7 @@ game_object := class(updateable, renderable):
     Update<override>():void = {}
     Render<override>():void = {}
 -->
-<!-- 105-->
+<!-- 1051-->
 ```verse
 # game_object is comparable because renderable is unique
 G1 := game_object{}
@@ -2900,7 +2900,7 @@ token := class<unique>:
 container := class:
     MyToken:token = token{}
 -->
-<!-- 106-->
+<!-- 1061-->
 ```verse
 C1 := container{}
 C2 := container{}
@@ -2941,7 +2941,7 @@ with_optional := class:
 with_map := class:
     ItemMap:[int]item = map{0 => item{}}
 -->
-<!-- 107-->
+<!-- 1071-->
 ```verse
 A := with_array{}
 B := with_array{}

--- a/docs/10_classes_interfaces.md
+++ b/docs/10_classes_interfaces.md
@@ -1056,8 +1056,10 @@ Understanding execution order is crucial for correct initialization:
    they're written in the archetype
 2. **Delegating constructor:** Subclass fields are initialized first,
    then the parent constructor runs
-3. **Class body blocks:** When using direct archetype construction,
-   blocks in the class definition execute before field initialization
+3. **Class body blocks:** Blocks and field initializers execute
+   together, in the order they appear in the class definition. By the
+   time a block runs, every field declared above it, including values
+   supplied by the archetype, is already initialized
 
 For delegating constructors to parent classes:
 

--- a/docs/10_classes_interfaces.md
+++ b/docs/10_classes_interfaces.md
@@ -1056,10 +1056,8 @@ Understanding execution order is crucial for correct initialization:
    they're written in the archetype
 2. **Delegating constructor:** Subclass fields are initialized first,
    then the parent constructor runs
-3. **Class body blocks:** Blocks and field initializers execute
-   together, in the order they appear in the class definition. By the
-   time a block runs, every field declared above it, including values
-   supplied by the archetype, is already initialized
+3. **Class body blocks:** When using direct archetype construction,
+   blocks in the class definition execute before field initialization
 
 For delegating constructors to parent classes:
 

--- a/docs/10_classes_interfaces.md
+++ b/docs/10_classes_interfaces.md
@@ -1231,7 +1231,7 @@ e := class(d):
     (e:)F(X:int):int = X + 2 # NEW method with same name, not an override
 
 # e now contains BOTH methods:
-#    - (d:)F inherited from d
+#    - (c:)F inherited from c (overridden in d)
 #    - (e:)F newly defined in e
 ```
 

--- a/docs/11_types.md
+++ b/docs/11_types.md
@@ -1594,9 +1594,8 @@ compile-time type safety and runtime flexibility.
 The `subtype(T)` type constructor represents runtime type values that
 are subtypes of `T`. Unlike `concrete_subtype` and `castable_subtype`,
 which are specialized for classes and interfaces, `subtype(T)` works
-with a wide range of types in Verse, including primitives and enums,
-not just classes and interfaces. (Collection and function types
-currently have limitations. See the note below.)
+with **any type** in Verse, including primitives, enums, collections,
+and function types.
 
 <!--versetest
 animal := class<computes> {}

--- a/docs/11_types.md
+++ b/docs/11_types.md
@@ -2205,7 +2205,7 @@ f()<reads>:void =
 
 <#
 -->
-<!-- 1215 -->
+<!-- 125 -->
 ```verse
 ComponentSet:classifiable_subset(component) = MakeClassifiableSubset()
 

--- a/docs/11_types.md
+++ b/docs/11_types.md
@@ -333,7 +333,7 @@ ProcessComponent(Comp:component):void =
 ```
 <!-- #> -->
 
-The cast expression evaluates to `false` if the runtime type doesn't
+The cast expression fails if the runtime type doesn't
 match, allowing you to use it directly in conditionals. The optional
 binding pattern `(Variable := Expression)` both performs the cast and
 binds the result to a variable when successful.
@@ -1347,7 +1347,7 @@ In function types, `void` participates in variance:
 ```verse
 IntIdentity(X:int):int = X
 
-# Contravariant return: supertype in return position
+# Covariant return: subtype allowed in return position
 F:int->void = IntIdentity  # int->int → int->void ✓
 # void is supertype of int, so this works
 
@@ -1594,8 +1594,9 @@ compile-time type safety and runtime flexibility.
 The `subtype(T)` type constructor represents runtime type values that
 are subtypes of `T`. Unlike `concrete_subtype` and `castable_subtype`,
 which are specialized for classes and interfaces, `subtype(T)` works
-with **any type** in Verse, including primitives, enums, collections,
-and function types.
+with a wide range of types in Verse, including primitives and enums,
+not just classes and interfaces. (Collection and function types
+currently have limitations. See the note below.)
 
 <!--versetest
 animal := class<computes> {}

--- a/docs/12_access.md
+++ b/docs/12_access.md
@@ -216,7 +216,7 @@ entities.
 A scoped access level is created using the `scoped{...}` expression,
 which takes one or more module references:
 
-<!-- NoCompile -->
+<!--NoCompile-->
 ```verse
 Collaboration := module:
     # Create a scope that includes both ModuleA and ModuleB
@@ -382,7 +382,7 @@ specific member, but doesn't make intermediate types or modules
 visible. To access a scoped member, you must be able to see the entire
 path to it:
 
-<!-- NoCompile -->
+<!--NoCompile-->
 ```verse
 Outer := module:
     # Internal to outer
@@ -450,7 +450,7 @@ Scoped access excels at creating controlled API boundaries where
 certain functionality should be shared between specific modules but
 not exposed as part of the public interface:
 
-<!-- NoCompile -->
+<!--NoCompile-->
 ```verse
 Networking := module:
     # Public scope for modules that need network access
@@ -678,7 +678,7 @@ The `@experimental` annotation marks features that are not yet stable
 and may change or be removed in future versions. Experimental features
 can only be used when the `AllowExperimental` package flag is enabled:
 
-<!-- NoCompile -->
+<!--NoCompile-->
 ```verse
 # Mark a feature as experimental
 @experimental
@@ -1103,7 +1103,7 @@ CommentedParam<localizes>(Name:string) : message = "Hello {<# comment #>Name}"
 
 Localized messages **must be defined at module or snippet scope**. They cannot be defined inside functions:
 
-<!-- NoCompile -->
+<!--NoCompile-->
 ```verse
 # Valid: module scope
 MyModule := module:

--- a/docs/12_access.md
+++ b/docs/12_access.md
@@ -672,7 +672,7 @@ The `@deprecated` annotation can be applied to:
 #### @experimental
 
 !!! warning "Internal Feature"
-    @deprecated attribute is currently an internal feature and cannot be used by end-users.
+    @experimental attribute is currently an internal feature and cannot be used by end-users.
 
 The `@experimental` annotation marks features that are not yet stable
 and may change or be removed in future versions. Experimental features
@@ -1287,7 +1287,7 @@ MyModule := module:
     InternalMessage<localizes> : message = "Internal message"
 
     some_class := class:
-        PrivateMessage<localizes><private> : message = "Private message"  # private not allowed in module scopes
+        PrivateMessage<localizes><private> : message = "Private message"  # <private> is allowed here because this is class scope, not module scope
 ```
 <!-- #> -->
 

--- a/docs/12_access.md
+++ b/docs/12_access.md
@@ -1287,7 +1287,7 @@ MyModule := module:
     InternalMessage<localizes> : message = "Internal message"
 
     some_class := class:
-        PrivateMessage<localizes><private> : message = "Private message"  # <private> is allowed here because this is class scope, not module scope
+        PrivateMessage<localizes><private> : message = "Private message"
 ```
 <!-- #> -->
 

--- a/docs/13_effects.md
+++ b/docs/13_effects.md
@@ -929,7 +929,7 @@ weapon:=struct<computes>{Type:weapon_type,Dammage:int}
 weapon_type:=enum:
     Sword
 -->
-<!-- 32 -->
+<!-- 321 -->
 ```verse
 # API promises it might read state
 GetDefaultWeapon<public>()<reads>:weapon =

--- a/docs/13_effects.md
+++ b/docs/13_effects.md
@@ -571,7 +571,7 @@ F:type{_(:int)<computes><decides>:int} = PureAdd
 
 # Calling through the variable
 Result := F[5]  # Must use [] syntax since type has <decides>
-# Returns option{6} since PureAdd never fails
+# Returns 6 since PureAdd never fails
 ```
 
 In this example, `PureAdd` has only `<computes>`, but it can be

--- a/docs/14_concurrency.md
+++ b/docs/14_concurrency.md
@@ -714,7 +714,7 @@ equivalent to the Canceled state. (alias)
 ### Task.Cancel()
 
 !!! note "Unreleased Feature"
-    The Cancel() method has not be released at this time.
+    The Cancel() method has not been released at this time.
 	
 The `Cancel()` method requests cancellation of a task. This is a safe
 operation that can be called on any task in any state:

--- a/docs/15_live_variables.md
+++ b/docs/15_live_variables.md
@@ -457,7 +457,7 @@ The body must have the `<transacts>` effect (see [Effects](13_effects.md)), allo
 
 The `when` expression provides continuous reactive behavior: every time a condition is true, execute some code. This creates a persistent observer that runs whenever its guard succeeds.
 
-<!--verstest-->
+<!--versetest-->
 <!-- 13 FAILURE
   Line 6: Verse compiler error V3560: Expected definition but found macro invocation.
   Line 10: Verse compiler error V3560: Expected definition but found assignment.

--- a/docs/16_modules.md
+++ b/docs/16_modules.md
@@ -1038,10 +1038,10 @@ Config := module:
 
 # How the compiler sees it:
 (/YourPackage:)Config := module:
-    (/YourPackage/config:)MaxPlayers<public>:(/Verse.org/Verse:)int = 100
+    (/YourPackage/Config:)MaxPlayers<public>:(/Verse.org/Verse:)int = 100
 
-    (/YourPackage/config:)GetPlayerLimit<public>():(/Verse.org/Verse:)int =
-        (/YourPackage/config:)MaxPlayers
+    (/YourPackage/Config:)GetPlayerLimit<public>():(/Verse.org/Verse:)int =
+        (/YourPackage/Config:)MaxPlayers
 ```
 
 All built-in types are qualified with their standard library
@@ -1565,8 +1565,8 @@ using { /GameB/Combat }
 Damage := CalculateDamage(10.0)  # Error: which CalculateDamage?
 
 # Explicit
-DamageA := /GameA/Combat.CalculateDamage(10.0)  # Clear
-DamageB := /GameB/Combat.CalculateDamage(10.0)  # Clear
+DamageA := (/GameA/Combat:)CalculateDamage(10.0)  # Clear
+DamageB := (/GameB/Combat:)CalculateDamage(10.0)  # Clear
 ```
 
 ### Persistence Issues

--- a/docs/16_modules.md
+++ b/docs/16_modules.md
@@ -1028,7 +1028,7 @@ Notice how `Health` and `TakeDamage` are qualified with `/YourPackage/player_cla
 
 **Module member qualification**: Definitions within modules are qualified with the module path:
 
-<!--MoCompile-->
+<!--NoCompile-->
 ```verse
 # What you write:
 Config := module:

--- a/docs/16_modules.md
+++ b/docs/16_modules.md
@@ -774,7 +774,7 @@ Thing<public>:rational = 1/3
 Thing<public>:rational = 10/3
 
 # - Make the type more specific (subtype)
-Thing<public>:int = 20  # nat is a subtype of int
+Thing<public>:int = 20  # int is a subtype of rational
 
 # Invalid updates (would be rejected):
 # - Remove the member

--- a/docs/VerseSyntaxValidation.md
+++ b/docs/VerseSyntaxValidation.md
@@ -82,7 +82,7 @@ game_item := class<final><persistable>:
             item_rarity.uncommon => 1.5
             item_rarity.rare => 2.0
             item_rarity.epic => 3.0
-            _ => false  # Fails if the item is legenday or unexpected
+            _ => false  # Fails if the item is legendary or unexpected
     
     # Computed property using closed-world function
     GetEffectiveValue()<transacts><decides> :int=
@@ -227,7 +227,7 @@ WaypointComponent<public> := class<final_super><abstract>(component) {
 ```
 
 ### Inline Text Example
-The example begins with Verse's rich type system. Types flow naturally through the code; many type annotations are omitted as they can be infered. When we do specify types, like `Items:[]game_item`, they document intent rather than just satisfy the compiler. The `item_rarity` enum provides type-safe constants without the boilerplate of traditional enumerations. The `item_stats` struct marked as `<persistable>` can be saved and loaded from persistent storage, essential for game saves. The `game_item` class uses `<unique>` to ensure reference equality semantics.
+The example begins with Verse's rich type system. Types flow naturally through the code; many type annotations are omitted as they can be inferred. When we do specify types, like `Items:[]game_item`, they document intent rather than just satisfy the compiler. The `item_rarity` enum provides type-safe constants without the boilerplate of traditional enumerations. The `item_stats` struct marked as `<persistable>` can be saved and loaded from persistent storage, essential for game saves. The `game_item` class uses `<unique>` to ensure reference equality semantics.
 
 ### UnrealEngine.digest.verse (Simplified)
 <!--NoCompile-->

--- a/docs/VerseSyntaxValidation.md
+++ b/docs/VerseSyntaxValidation.md
@@ -227,7 +227,7 @@ WaypointComponent<public> := class<final_super><abstract>(component) {
 ```
 
 ### Inline Text Example
-The example begins with Verse's rich type system. Types flow naturally through the code; many type annotations are omitted as they can be inferred. When we do specify types, like `Items:[]game_item`, they document intent rather than just satisfy the compiler. The `item_rarity` enum provides type-safe constants without the boilerplate of traditional enumerations. The `item_stats` struct marked as `<persistable>` can be saved and loaded from persistent storage, essential for game saves. The `game_item` class uses `<unique>` to ensure reference equality semantics.
+The example begins with Verse's rich type system. Types flow naturally through the code; many type annotations are omitted as they can be inferred. When we do specify types, like `Items:[]game_item`, they document intent rather than just satisfy the compiler. The `item_rarity` enum provides type-safe constants without the boilerplate of traditional enumerations. The `item_stats` struct marked as `<persistable>` can be saved and loaded from persistent storage, essential for game saves. The `game_item` class is marked `<final>` and `<persistable>` so its instances can be saved and restored; because persistable data is serialized by value, such classes cannot also be `<unique>`.
 
 ### UnrealEngine.digest.verse (Simplified)
 <!--NoCompile-->

--- a/docs/concept_index.md
+++ b/docs/concept_index.md
@@ -6,7 +6,7 @@ This index provides quick access to key concepts, language features, and importa
 
 ### Primitive Types
 - **any** - universal supertype: [Primitives - Any](02_primitives.md#any), [Type System](11_types.md)
-- **void** - empty type: [Primitives - Void](02_primitives.md#void), [Type System](11_types.md)
+- **void** - universal supertype (contains all values): [Primitives - Void](02_primitives.md#void), [Type System](11_types.md)
 - **logic** - boolean values: [Primitives - Booleans](02_primitives.md#booleans), [Type System](11_types.md)
 - **int** - integers: [Overview](00_overview.md), [Primitives - Integers](02_primitives.md#integers), [Type System](11_types.md)
 - **float** - floating-point: [Overview](00_overview.md), [Primitives - Floats](02_primitives.md#floats), [Type System](11_types.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,8 +70,8 @@ nav:
   - Home: index.md
   - Overview: 00_overview.md
   - Expressions: 01_expressions.md
-  - Primitives types: 02_primitives.md
-  - Containers types: 03_containers.md
+  - Primitive types: 02_primitives.md
+  - Container types: 03_containers.md
   - Operators: 04_operators.md
   - Mutability: 05_mutability.md
   - Functions: 06_functions.md


### PR DESCRIPTION
## Summary
Documentation-only fixes from a full review of all 19 chapters + index pages.
12 commits, 16 files. `mkdocs build --strict` passes; link/anchor check clean.

## Fixes
- **Broken link:** stray `/` in `06_functions.md/#publishing-functions`
- **Wrong facts/outputs:** `Mod` is always non-negative (Euclidean); class-body
  block execution order; `void` is a universal supertype, not the empty type;
  drop `true`-as-"top type"; covariant return label; fallible cast *fails*
  (not `false`); remove illegal `<unique>` from a `<persistable>` class; narrow
  the `subtype(T)` claim; fix output comments (triangular rows, `Floor[-3.33]=-4`,
  capitalization, `F[5]=6`, `(c:)F` qualifier)
- **Syntax:** documented `(/Module:)member` qualification; path casing
- **Extraction:** `MoCompile`/`verstest`/`NoCompile ` marker typos; duplicate
  snippet ids
- **Housekeeping:** spelling/grammar; `@experimental` warning text
